### PR TITLE
chore: release 1.5.1

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+### Version 1.5.1(25/05/2023)
+
+- fix(ios): convert an iOS C99Ext-compliant identifier
+
 ### Version 1.5.0 (24/04/2023)
 
 - feat: screen protection, see `enableScreenProtection` and `disableScreenProtection`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-system",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-system",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "fs": "0.0.1-security",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.5.1",
   "name": "cordova-plugin-system",
   "cordova_name": "Cordova System Plugin",
   "description": "Cordova System Plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 		xmlns:android="http://schemas.android.com/apk/res/android"
 		id="cordova-plugin-system"
-		version="1.5.0">
+		version="1.5.1">
 
 	<name>Cordova System Plugin</name>
 	<description>System Plugin</description>


### PR DESCRIPTION
fix(ios): convert an iOS C99Ext-compliant identifier (#13)